### PR TITLE
check_postfix_mailqueue: Fixed warning in case of permission denied

### DIFF
--- a/check_postfix_mailqueue
+++ b/check_postfix_mailqueue
@@ -188,7 +188,8 @@ cd $SPOOLDIR >/dev/null 2>/dev/null || {
 
 # Get values
 for i in deferred active maildrop incoming corrupt hold; do
-    eval $i=`(test -d $i && find $i -type f ) | wc -l`
+    test -d $i && test -r $i || { echo -n "unable to check queue $i"; exit $STATE_CRIT; }
+    eval $i=$(qshape $i | grep "TOTAL" | awk '{print $2}')
 done
 
 for state in crit warn; do


### PR DESCRIPTION
Before if the find was failing, the script was returning OK.
Also a different way to check the queue has been implemented.